### PR TITLE
added do.js to list of files for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "node": ">=8.0.0"
   },
   "main": "./do.js",
-  "files": [],
+  "files": ["do.js"],
   "readmeFilename": "README.md",
   "scripts": {
     "test": "npm run lint && metatests test",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "node": ">=8.0.0"
   },
   "main": "./do.js",
-  "files": ["do.js"],
+  "files": [
+    "do.js"
+  ],
   "readmeFilename": "README.md",
   "scripts": {
     "test": "npm run lint && metatests test",


### PR DESCRIPTION
Currently latest version is broken

```bash
npm i do

node index.js
```

![image](https://user-images.githubusercontent.com/20462292/99190383-5aa0a100-2777-11eb-80f7-f8b6b6cd7a59.png)

```js
const chain = require('do');

const { readFile } = require('fs');

const c1 = chain
  .do(readFile, 'package.json')
  .do(readFile, 'package.json')
  .do(readFile, 'package.json');

c1((err, result) => {
  console.log('done');
  if (err) console.log(err);
  else console.dir({ result });
});
```