### PR TITLE
Change 'arrowParens' style to default ('always')

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -135,7 +135,7 @@
         "functions": false
       }
     ],
-    "arrow-parens": ["error", "as-needed"],
+    "arrow-parens": "off",
     "arrow-body-style": ["error", "as-needed"],
     "arrow-spacing": ["error"],
     "no-confusing-arrow": [

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,10 @@
 {
   "singleQuote": true,
   "trailingComma": "es5",
-  "overrides": [{ "files": ".prettierrc", "options": { "parser": "json" } }],
-  "arrowParens": "avoid"
+  "overrides": [
+    {
+      "files": ".prettierrc",
+      "options": { "parser": "json" }
+    }
+  ]
 }

--- a/do.js
+++ b/do.js
@@ -3,7 +3,7 @@
 function Do() {}
 
 const chain = function (fn, ...args) {
-  const current = done => {
+  const current = (done) => {
     if (done) current.done = done;
     if (current.prev) {
       current.prev.next = current;
@@ -137,7 +137,7 @@ Collector.prototype.then = function (fulfill, reject) {
 // Collector instance constructor
 //   expected <number> or array of string,
 // Returns: <Function> Collector
-const collect = expected => {
+const collect = (expected) => {
   const expectKeys = Array.isArray(expected) ? new Set(expected) : null;
   const fields = {
     expectKeys,

--- a/test/chain.js
+++ b/test/chain.js
@@ -10,7 +10,7 @@ const wrapAsync = (
   setTimeout(callback, Math.floor(Math.random() * 1000));
 };
 
-metatests.test('simple chain/do', test => {
+metatests.test('simple chain/do', (test) => {
   const readConfig = (name, callback) => {
     test.strictSame(name, 'myConfig');
     wrapAsync(() => {

--- a/test/collector.js
+++ b/test/collector.js
@@ -3,7 +3,7 @@
 const collect = require('..');
 const metatests = require('metatests');
 
-metatests.test('data collector functor', test => {
+metatests.test('data collector functor', (test) => {
   const expectedResult = {
     key1: 1,
     key2: 2,
@@ -23,7 +23,7 @@ metatests.test('data collector functor', test => {
   dc('key3', null, 3);
 });
 
-metatests.test('data collector method', test => {
+metatests.test('data collector method', (test) => {
   const expectedResult = {
     key1: 1,
     key2: 2,
@@ -43,7 +43,7 @@ metatests.test('data collector method', test => {
   dc.collect('key3', null, 3);
 });
 
-metatests.test('data collector', test => {
+metatests.test('data collector', (test) => {
   const expectedResult = { foo: 1, bar: 2 };
 
   const dc = collect(['foo', 'bar', 'foo'])
@@ -58,7 +58,7 @@ metatests.test('data collector', test => {
   dc.pick('bar', 2);
 });
 
-metatests.test('data collector with shorthand pick', test => {
+metatests.test('data collector with shorthand pick', (test) => {
   const expectedResult = { foo: 1, bar: 2 };
 
   const dc = collect(['foo', 'bar', 'foo'])
@@ -73,7 +73,7 @@ metatests.test('data collector with shorthand pick', test => {
   dc('bar', 2);
 });
 
-metatests.test('data collector', test => {
+metatests.test('data collector', (test) => {
   const expectedResult = {
     key1: 1,
     key2: 2,
@@ -93,7 +93,7 @@ metatests.test('data collector', test => {
   kc.collect('key3', null, 3);
 });
 
-metatests.test('distinct data collector', test => {
+metatests.test('distinct data collector', (test) => {
   const expectedResult = {
     key1: 2,
     key2: 2,
@@ -114,7 +114,7 @@ metatests.test('distinct data collector', test => {
   dc.pick('key3', 3);
 });
 
-metatests.test('distinct key collector', test => {
+metatests.test('distinct key collector', (test) => {
   const expectedResult = {
     key1: 2,
     key2: 2,
@@ -135,10 +135,10 @@ metatests.test('distinct key collector', test => {
   kc.pick('key3', 3);
 });
 
-metatests.test('data collector with repeated keys', test => {
+metatests.test('data collector with repeated keys', (test) => {
   const dc = collect(3)
     .timeout(100)
-    .done(err => {
+    .done((err) => {
       test.assert(err);
       test.end();
     });
@@ -148,10 +148,10 @@ metatests.test('data collector with repeated keys', test => {
   dc.collect('key2', null, 2);
 });
 
-metatests.test('key collector with repeated keys', test => {
+metatests.test('key collector with repeated keys', (test) => {
   const kc = collect(['key1', 'key2', 'key3'])
     .timeout(100)
-    .done(err => {
+    .done((err) => {
       test.assert(err);
       test.end();
     });
@@ -161,7 +161,7 @@ metatests.test('key collector with repeated keys', test => {
   kc.collect('key2', null, 2);
 });
 
-metatests.test('collect with error', test => {
+metatests.test('collect with error', (test) => {
   const testErr = new Error('Test error');
   const col = collect(1);
   col.done((err, res) => {
@@ -172,7 +172,7 @@ metatests.test('collect with error', test => {
   col.fail('someKey', testErr);
 });
 
-metatests.test('collect with error (shorthand fail)', test => {
+metatests.test('collect with error (shorthand fail)', (test) => {
   const testErr = new Error('Test error');
   const col = collect(1);
   col.done((err, res) => {
@@ -183,7 +183,7 @@ metatests.test('collect with error (shorthand fail)', test => {
   col('someKey', testErr);
 });
 
-metatests.test('collect method calling after it is done', test => {
+metatests.test('collect method calling after it is done', (test) => {
   const col = collect(1);
   col.done((err, res) => {
     test.error(err);
@@ -194,7 +194,7 @@ metatests.test('collect method calling after it is done', test => {
   col.pick('someKey2', 'someVal2');
 });
 
-metatests.test('keys collector receives wrong key', test => {
+metatests.test('keys collector receives wrong key', (test) => {
   const col = collect(['rightKey']);
   col.done((err, res) => {
     test.error(err);
@@ -205,9 +205,9 @@ metatests.test('keys collector receives wrong key', test => {
   col.pick('rightKey', 'someVal');
 });
 
-metatests.test('distinct keys collector receives wrong key', test => {
+metatests.test('distinct keys collector receives wrong key', (test) => {
   const col = collect(['rightKey']).distinct();
-  col.done(err => {
+  col.done((err) => {
     test.assert(err);
     test.end();
   });
@@ -215,7 +215,7 @@ metatests.test('distinct keys collector receives wrong key', test => {
   col.pick('rightKey', 'someVal');
 });
 
-metatests.test('collect with take', test => {
+metatests.test('collect with take', (test) => {
   const col = collect(1);
   col.done((err, res) => {
     test.error(err);
@@ -226,7 +226,7 @@ metatests.test('collect with take', test => {
   col.take('someKey', af, 'someVal');
 });
 
-metatests.test('collect with shorthand take', test => {
+metatests.test('collect with shorthand take', (test) => {
   const col = collect(1);
   col.done((err, res) => {
     test.error(err);
@@ -237,7 +237,7 @@ metatests.test('collect with shorthand take', test => {
   col('someKey', af, 'someVal');
 });
 
-metatests.test('collect generate callback', test => {
+metatests.test('collect generate callback', (test) => {
   const col = collect(1);
   col.done((err, res) => {
     test.error(err);
@@ -248,7 +248,7 @@ metatests.test('collect generate callback', test => {
   af('someVal', col.callback('someKey'));
 });
 
-metatests.test('collect generate callback shorthand', test => {
+metatests.test('collect generate callback shorthand', (test) => {
   const col = collect(1);
   col.done((err, res) => {
     test.error(err);
@@ -259,7 +259,7 @@ metatests.test('collect generate callback shorthand', test => {
   af('someVal', col('someKey'));
 });
 
-metatests.test('collect with timeout error', test => {
+metatests.test('collect with timeout error', (test) => {
   const timeoutErr = new Error('Collector timeout');
   const col = collect(1)
     .done((err, res) => {
@@ -272,7 +272,7 @@ metatests.test('collect with timeout error', test => {
   col.take('someKey', af, 'someVal');
 });
 
-metatests.test('collect with take calls bigger than expected', test => {
+metatests.test('collect with take calls bigger than expected', (test) => {
   const col = collect(1).done((err, res) => {
     test.error(err);
     test.strictSame(Object.keys(res).length, 1);
@@ -283,8 +283,8 @@ metatests.test('collect with take calls bigger than expected', test => {
   col.take('someKey2', af, 'someVal2');
 });
 
-metatests.test('cancel data collector', test => {
-  const dc = collect(3).done(err => {
+metatests.test('cancel data collector', (test) => {
+  const dc = collect(3).done((err) => {
     test.assert(err);
     test.end();
   });
@@ -293,8 +293,8 @@ metatests.test('cancel data collector', test => {
   dc.cancel();
 });
 
-metatests.test('cancel key collector', test => {
-  const dc = collect(['uno', 'due']).done(err => {
+metatests.test('cancel key collector', (test) => {
+  const dc = collect(['uno', 'due']).done((err) => {
     test.assert(err);
     test.end();
   });
@@ -303,13 +303,13 @@ metatests.test('cancel key collector', test => {
   dc.cancel();
 });
 
-metatests.test('collect then success', test => {
+metatests.test('collect then success', (test) => {
   const col = collect(1).then(
-    result => {
+    (result) => {
       test.assert(result);
       test.end();
     },
-    err => {
+    (err) => {
       test.error(err);
       test.end();
     }
@@ -317,15 +317,15 @@ metatests.test('collect then success', test => {
   col.pick('Key', 'value');
 });
 
-metatests.test('collect then fail', test => {
+metatests.test('collect then fail', (test) => {
   collect(5)
     .timeout(10)
     .then(
-      result => {
+      (result) => {
         test.error(result);
         test.end();
       },
-      err => {
+      (err) => {
         test.assert(err);
         test.end();
       }


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
